### PR TITLE
Proposal: remove controller test req

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Regardless of how you choose to implement this project or how it progresses over
   - A fresh branch for each new feature
   - Regular commits
   - Descriptive commit messages
-- Fanatical devotion to **test-driven development**
+- Fanatical devotion to **testing the model**
   - Pseudocode first, then write the tests, then write code to make them pass (with the exception of when we encourage otherwise)
+  - **Note:** This project has no requirements around writing controller tests; instead, our prioritized learning goal this week is model tests. We will revisit controller tests immediately after this project.
 - Steadfast adherence to **agile development practices**
   - User stories should be listed and prioritized using a Trello board
   - The finished application should be deployed to Heroku (deploy early, deploy often)
@@ -73,7 +74,7 @@ Regardless of how you choose to implement this project or how it progresses over
 
 ### Wave 1
 
-In this wave, you should build some functionality, and then build the tests for that functionality. We recommend doing the read and create operations first, then writing tests, then completing the update and delete operations.
+In this wave, you should build some functionality, and then build the model tests relevant to that functionality. We recommend doing the read and create operations first, then writing tests, then completing the update and delete operations.
 
 Mimic the site's basic functionality around Media, without worrying (yet) about Users or Votes:
 - Build a main page, with a list of the media for each category, as well as a spotlight section for the top media overall.
@@ -85,18 +86,20 @@ Mimic the site's basic functionality around Media, without worrying (yet) about 
 
 #### Hints for Refactoring
 
-Think about what functionality should live in the model. Given that the way you select the spotlight and top-10 are going to change in a future wave, how can you isolate this business logic to make it easy to change?
+Think about what logic should live in the model. Given that the way you select the spotlight and top-10 are going to change in a future wave, how can you isolate this business logic to make it easy to change?
 
-#### Testing
+#### Required Testing: Models
 
-**Before** moving on to wave 2, your project should contain the following tests
+**Before** moving on to wave 2, your project should contain the following tests:
 
-**Model Testing**
 - All validations and should be tested
 - All custom methods should be tested
     - For top-10 or spotlight, what if there are less than 10 works? What if there are no works?
 
-**Controller Testing**
+#### Optional Testing: Controllers
+
+Consider these features and the tests that would go with them for your controllers. If it is helpful, write them and use them!
+
 - Tests for standard CRUD operations on works
 - Does the main page load if there are no works?
 
@@ -111,24 +114,27 @@ Refactor your current site to utilize this new functionality:
 - Change the media spotlight and top-10 to respect vote count
 - All lists of media (including top ten lists on the front page) are sorted in a specific way on the demo site. How? Implement this sorting on your site
 
-#### Testing
+#### Required Testing: Models
 
 **Before** moving on to wave 3, your project should contain the following tests
 
-**Model Testing**
 - All validations for new models should be tested
 - All relations between models should be tested
 - Your tests for custom model methods should be updated to reflect the presence of votes
     - How do top-10 and spotlight handle works with no votes? Ties in the number of votes?
 
-**Controller Testing**
+
+#### Optional Testing: Controllers
+
+Consider these features and the tests that would go with them for your controllers. If it is helpful, write them and use them!
+
 - Tests for all individual actions
 - Authentication tests combining multiple actions
     - A guest user _cannot_ vote if they have not logged in
     - A logged-in user _can_ vote for a work they haven't already voted for
     - A logged-in user _cannot_ vote for a work they have previously voted for
 
-Focus on testing voting logic since this is the most complex part of Wave 2.
+Focus on the tests for voting logic since this is the most complex part of Wave 2.
 
 #### A note on logging in
 
@@ -140,7 +146,14 @@ Passwords and security are tricky! We'll talk about that sort of thing a little 
 
 ### Optional Enhancements
 
-Use Bootstrap and CSS to style the site to match the example. The layout as well as the look and feel should match as close as possible. Yes, you are free to use browser dev tools to inspect, read, and even copy/paste the styles from the demo page.
+#### High Priority Optionals
+
+1. Use Bootstrap and CSS to style the site to match the example. The layout as well as the look and feel should match as close as possible. Yes, you are free to use browser dev tools to inspect, read, and even copy/paste the styles from the demo page.
+1. Write the controller tests for all CRUD operations
+1. Write the controller tests for the nominal test cases of voting functionality
+1. Write the controller tests for the edge test cases of voting functionality
+
+#### Low Priority Optionals
 
 Once your test coverage is comprehensive, your HTML is semantic, your user stories have all been moved to the `Done` column and your application has been deployed to Heroku, you may consider the following enhancements:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ You are encouraged to build your own `seeds.rb` script using the `media-seeds.cs
 
 The file `generate_starter_data.rb` is a script to help generate a new `media-seeds.csv` file. There are comments in the file about its use. You are not required to use this file.
 
-## Non-Functional Requirements
+---
+
+# Non-Functional Requirements
 
 Regardless of how you choose to implement this project or how it progresses over time, your workflow should exhibit:
 
@@ -70,9 +72,9 @@ Regardless of how you choose to implement this project or how it progresses over
   - The finished application should be deployed to Heroku (deploy early, deploy often)
 - Unrelenting use of **semantic HTML**
 
-## Functional Requirements
+# Functional Requirements
 
-### Wave 1
+## Wave 1
 
 In this wave, you should build some functionality, and then build the model tests relevant to that functionality. We recommend doing the read and create operations first, then writing tests, then completing the update and delete operations.
 
@@ -84,11 +86,11 @@ Mimic the site's basic functionality around Media, without worrying (yet) about 
 - Build a details page for each piece of media
 - Allow users to edit and delete works
 
-#### Hints for Refactoring
+### Hints for Refactoring
 
 Think about what logic should live in the model. Given that the way you select the spotlight and top-10 are going to change in a future wave, how can you isolate this business logic to make it easy to change?
 
-#### Required Testing: Models
+### Required Testing: Models
 
 **Before** moving on to wave 2, your project should contain the following tests:
 
@@ -96,14 +98,14 @@ Think about what logic should live in the model. Given that the way you select t
 - All custom methods should be tested
     - For top-10 or spotlight, what if there are less than 10 works? What if there are no works?
 
-#### Optional Testing: Controllers
+### Optional Testing: Controllers
 
 Consider these features and the tests that would go with them for your controllers. If it is helpful, write them and use them!
 
 - Tests for standard CRUD operations on works
 - Does the main page load if there are no works?
 
-### Wave 2
+## Wave 2
 
 Mimic the site's functionality around Users and Voting:
 - Allow users to "log in" to the site, and use the `session` to keep track of which user is currently logged in for a given browser
@@ -114,7 +116,7 @@ Refactor your current site to utilize this new functionality:
 - Change the media spotlight and top-10 to respect vote count
 - All lists of media (including top ten lists on the front page) are sorted in a specific way on the demo site. How? Implement this sorting on your site
 
-#### Required Testing: Models
+### Required Testing: Models
 
 **Before** moving on to wave 3, your project should contain the following tests
 
@@ -124,7 +126,7 @@ Refactor your current site to utilize this new functionality:
     - How do top-10 and spotlight handle works with no votes? Ties in the number of votes?
 
 
-#### Optional Testing: Controllers
+### Optional Testing: Controllers
 
 Consider these features and the tests that would go with them for your controllers. If it is helpful, write them and use them!
 
@@ -136,24 +138,24 @@ Consider these features and the tests that would go with them for your controlle
 
 Focus on the tests for voting logic since this is the most complex part of Wave 2.
 
-#### A note on logging in
+### A note on logging in
 
 Passwords and security are tricky! We'll talk about that sort of thing a little in the coming weeks, but for now you don't need to provide any sort of security. The user gives you a username, and your site should just trust them.
 
-### Wave 3
+## Wave 3
 - Add a list of voting users to the details page for each media
 - Add a page for each user, as well as a page showing a summary of all users
 
-### Optional Enhancements
+## Optional Enhancements
 
-#### High Priority Optionals
+### High Priority Optionals
 
 1. Use Bootstrap and CSS to style the site to match the example. The layout as well as the look and feel should match as close as possible. Yes, you are free to use browser dev tools to inspect, read, and even copy/paste the styles from the demo page.
 1. Write the controller tests for all CRUD operations
 1. Write the controller tests for the nominal test cases of voting functionality
 1. Write the controller tests for the edge test cases of voting functionality
 
-#### Low Priority Optionals
+### Low Priority Optionals
 
 Once your test coverage is comprehensive, your HTML is semantic, your user stories have all been moved to the `Done` column and your application has been deployed to Heroku, you may consider the following enhancements:
 


### PR DESCRIPTION
As we re-ordered some content in C11 and brought controller testing from after MR (aka Week 12), to before MR (aka Week 9), we added controller testing requirements to the MR project without taking away any requirements.

Looking back at this now, not only was MR unsuccessful in C11 because of schedule, but also because of this.


I've considered providing controller tests, but I hesitate on this because the project doesn't require specific controllers, and we actually get some good variation on controllers on this project


I've looked over [the Media Ranker Revisited project that we assign the following week](https://github.com/AdaGold/media-ranker-revisited), whose three learning goals are:
1. Impl OAuth
2. Review Controller Tests
3. Impl and Test authentication and authorization

And I feel pretty confident that controller tests on original Media Ranker is redundant with that


Therefore, my proposal is to cut it, and encourage students to consider the controller tests during each wave, and implement as an optional.

Let me know what thoughts, ideas, etc y'all have